### PR TITLE
Use CMake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,15 @@ FROM alpine:latest as builder
 LABEL maintainer="Anton Egorov <anton@egorov.li>"
 
 RUN apk --update --no-cache add \
-  autoconf \
-  automake \
   build-base \
+  cmake \
   git \
-  libtool \
   nasm
 
 WORKDIR /src/mozjpeg
 RUN git clone git://github.com/mozilla/mozjpeg.git ./
 
-RUN autoreconf -fiv \
-  && ./configure \
+RUN cmake -G"Unix Makefiles" -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 .. \
   && make install prefix=/usr/local libdir=/usr/local/lib64
 
 FROM alpine:latest


### PR DESCRIPTION
As this image builds from mozjpeg git rather than an image tag it breaks now due to libjpeg-turbo 2.0.0 merge and upcoming v3.4.0 of mozjpeg dropping autotools and only supporting CMake as mentioned in #1 .

Closes #1